### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/lelondir/5c6c7410-149f-4112-97ae-d38a790e4b7d/3bd77118-43d1-45aa-9b90-e3d5f2ecb0ae/_apis/work/boardbadge/d2556464-b3b8-400e-86be-b366b34ec3e1)](https://dev.azure.com/lelondir/5c6c7410-149f-4112-97ae-d38a790e4b7d/_boards/board/t/3bd77118-43d1-45aa-9b90-e3d5f2ecb0ae/Microsoft.RequirementCategory)
 # gameoff2020
 Github para o Jogo da GameOff 2020


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/lelondir/5c6c7410-149f-4112-97ae-d38a790e4b7d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.